### PR TITLE
Make session shell isolation pluggable (just-bash default, Docker container opt-in)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,25 @@ To use a purely in-memory virtual filesystem instead, set an environment variabl
 
 In realistic server deployments it would be better to use disk rather than in-memory storage, because disk space is more cheaply available. But if you're building a client-side application that creates large numbers of short-lived agent sessions, it might work well to use an in-memory VFS.
 
+### Switching to container-based isolation
+
+By default, each session's shell tool is powered by [just-bash](https://github.com/aspect-build/just-bash), an in-process virtual filesystem and shell simulator. This is the simplest option: it needs no extra setup at all.
+
+As an alternative, this sample also includes a container-based isolation strategy: each session gets its own small, disposable Linux container (built from `app/session-image/Dockerfile`), and the `bash` tool runs commands for real inside it. The session's directory on disk is bind-mounted read-write into the container, so file tools and the `bash` tool both operate on the same files.
+
+Both strategies implement the same `SessionEnvironment` interface (see `app/src/api/environments/types.ts`), so switching between them is a one-line change in `app/src/api/environments/index.ts`:
+
+```ts
+export const createEnvironment: CreateEnvironment = createJustBashEnvironment;
+// export const createEnvironment: CreateEnvironment = createContainerEnvironment;
+```
+
+To switch, comment out the first line and uncomment the second. This requires:
+
+- Docker installed and running on the machine that runs the app server.
+- Disk-backed session storage (the default) rather than the in-memory VFS mode above, since containers need a real host directory to bind-mount.
+- If you're also running the app server itself via `docker-compose` (rather than `npm run dev` directly on the host), uncomment the Docker socket bind mount and `HOST_SESSIONS_DIR` lines in `docker-compose.yml`, so the app can talk to the host's Docker daemon to start sibling containers with correctly-resolved bind mount paths.
+
 ## Architecture
 
 ```mermaid
@@ -52,9 +71,8 @@ When a user connects, the app server creates an isolated session with:
 
 - A **Copilot SDK session** (`CopilotSession`) that maintains conversation state, tool handlers, and event streaming.
   - We limit it to using tools that are intended to be safe in multi-user environments because they don't read/write files.
-  - The session's only tool that can operate on disk is `bash`, but this is swapped out for a virtual version (see below).
-- A **virtual filesystem** (in-memory or disk-backed) scoped to that session. The Copilot agent reads and writes files within this filesystem only. It cannot see the server's disk or the state of other sessions.
-- A **virtual bash runtime** ([just-bash](https://github.com/aspect-build/just-bash)) attached to the virtual filesystem, exposed to the agent as a tool. Network access is restricted to a small allowlist.
+  - The session's only tool that can operate on disk is `bash`, but this is swapped out for an isolated version (see below).
+- A **session environment** (see `app/src/api/environments/`) providing an isolated filesystem and a `bash` tool. Two implementations are included - the default uses [just-bash](https://github.com/aspect-build/just-bash), an in-process virtual filesystem and shell simulator; an alternative runs each session in its own small, disposable Linux container instead. See [Switching to container-based isolation](#switching-to-container-based-isolation).
 
 Multiple browser tabs can observe the same session simultaneously — the server maintains a single `CopilotSession` per session ID and fans out events to all connected WebSockets. To see this, copy and paste your session URL into a second browser window or tab.
 
@@ -76,7 +94,8 @@ The `rsync-filestore` container is a minimal Alpine image running an rsync daemo
    * `api`: server-side code that defines and manages agent sessions
      * `chatSocket.ts`: starts a WebSocket listener. As clients connect/disconnect, starts and stops `CopilotSession` instances and synchronizes storage to `rsync-filestore`
      * `storage/`: simple VFS implementations
-     * `bash.ts`: swaps out Copilot SDK's built-in shell tool with one backed by [just-bash](https://github.com/vercel-labs/just-bash). This is simply an example - you could instead map it into a per-session container, any other isolated shell. Various other open source projects provide isolated shells.
+     * `environments/`: pluggable session isolation strategies (see [Switching to container-based isolation](#switching-to-container-based-isolation)). `justBashEnvironment.ts` is the default; `containerEnvironment.ts` is the container-based alternative. Both implement the same `SessionEnvironment` interface (`types.ts`), selected by a single line in `index.ts`.
+     * `bash.ts`: swaps out Copilot SDK's built-in shell tool with one backed by [just-bash](https://github.com/vercel-labs/just-bash), used by the default `justBashEnvironment`.
    * `web-ui`: an Express+React application providing the user interface
      * `hooks/useChat.ts`: opens the websocket connection to `api/chat` and uses a reducer pattern to convert the event stream into a UI
      * everything else: generic chat UI (a lot of code but nothing interesting)

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -12,6 +12,7 @@
         "@github/copilot-sdk": "^1.0.5",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "dockerode": "^5.0.1",
         "express": "^4.21.0",
         "just-bash": "^2.14.0",
         "lucide-react": "^1.7.0",
@@ -34,6 +35,7 @@
       "devDependencies": {
         "@tailwindcss/typography": "^0.5.19",
         "@tailwindcss/vite": "^4.2.2",
+        "@types/dockerode": "^4.0.1",
         "@types/express": "^5.0.0",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
@@ -491,6 +493,12 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@balena/dockerignore": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@balena/dockerignore/-/dockerignore-1.0.2.tgz",
+      "integrity": "sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==",
+      "license": "Apache-2.0"
     },
     "node_modules/@base-ui/react": {
       "version": "1.3.0",
@@ -1352,6 +1360,55 @@
         "copilot-win32-x64": "copilot.exe"
       }
     },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+      "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.8.0",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@grpc/grpc-js/node_modules/@grpc/proto-loader": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
+      "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.7.15",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
+      "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@hono/node-server": {
       "version": "1.19.12",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.12.tgz",
@@ -1532,6 +1589,16 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
       }
     },
     "node_modules/@mixmark-io/domino": {
@@ -1984,6 +2051,63 @@
       "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
       "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
       "license": "MIT"
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@radix-ui/number": {
       "version": "1.1.1",
@@ -4416,6 +4540,29 @@
         "@types/ms": "*"
       }
     },
+    "node_modules/@types/docker-modem": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/docker-modem/-/docker-modem-3.0.6.tgz",
+      "integrity": "sha512-yKpAGEuKRSS8wwx0joknWxsmLha78wNMe9R2S3UNsVOkZded8UqOrV8KoeDXoXsjndxwyF3eIhyClGbO1SEhEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/ssh2": "*"
+      }
+    },
+    "node_modules/@types/dockerode": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/dockerode/-/dockerode-4.0.1.tgz",
+      "integrity": "sha512-cmUpB+dPN955PxBEuXE3f6lKO1hHiIGYJA46IVF3BJpNsZGvtBDcRnlrHYHtOH/B6vtDOyl2kZ2ShAu3mgc27Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/docker-modem": "*",
+        "@types/node": "*",
+        "@types/ssh2": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -4491,7 +4638,6 @@
       "version": "25.5.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
@@ -4550,6 +4696,33 @@
         "@types/http-errors": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/ssh2": {
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-1.15.5.tgz",
+      "integrity": "sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^18.11.18"
+      }
+    },
+    "node_modules/@types/ssh2/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/ssh2/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/statuses": {
       "version": "2.0.6",
@@ -4719,6 +4892,15 @@
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
     },
+    "node_modules/asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
     "node_modules/ast-types": {
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
@@ -4768,8 +4950,7 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.12",
@@ -4783,12 +4964,20 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
     "node_modules/bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
@@ -4910,10 +5099,18 @@
         }
       ],
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buildcheck": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.7.tgz",
+      "integrity": "sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==",
+      "optional": true,
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/bundle-name": {
@@ -5064,8 +5261,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/class-variance-authority": {
       "version": "0.7.1",
@@ -5315,6 +5511,20 @@
         }
       }
     },
+    "node_modules/cpu-features": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.10.tgz",
+      "integrity": "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "buildcheck": "~0.0.6",
+        "nan": "^2.19.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -5561,6 +5771,38 @@
         "node": ">=0.3.1"
       }
     },
+    "node_modules/docker-modem": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-5.0.7.tgz",
+      "integrity": "sha512-XJgGhoR/CLpqshm4d3L7rzH6t8NgDFUIIpztYlLHIApeJjMZKYJMz2zxPsYxnejq5h3ELYSw/RBsi3t5h7gNTA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "readable-stream": "^3.5.0",
+        "split-ca": "^1.0.1",
+        "ssh2": "^1.15.0"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/dockerode": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-5.0.1.tgz",
+      "integrity": "sha512-avsq/xk4YPIrn0CgleX5bjT9Y8IT1p9PxrNQ++RBQ2WEyFfHCTDsT9kmyxz+H/axnjAwg8wJWEIuPGOUuNupiA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@balena/dockerignore": "^1.0.2",
+        "@grpc/grpc-js": "^1.11.1",
+        "@grpc/proto-loader": "^0.7.13",
+        "docker-modem": "^5.0.7",
+        "protobufjs": "^7.3.2",
+        "tar-fs": "^2.1.4"
+      },
+      "engines": {
+        "node": ">= 14.17"
+      }
+    },
     "node_modules/dotenv": {
       "version": "17.3.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
@@ -5636,7 +5878,6 @@
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -6180,8 +6421,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fs-extra": {
       "version": "11.3.4",
@@ -7297,6 +7537,12 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "license": "MIT"
     },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
     "node_modules/log-symbols": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
@@ -7324,6 +7570,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
     },
     "node_modules/longest-streak": {
       "version": "3.1.0",
@@ -8403,8 +8655,7 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/modern-tar": {
       "version": "0.7.6",
@@ -8492,6 +8743,13 @@
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
+    },
+    "node_modules/nan": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.28.0.tgz",
+      "integrity": "sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -9075,6 +9333,29 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/protobufjs": {
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -9093,7 +9374,6 @@
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
       "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -9472,7 +9752,6 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -10184,6 +10463,12 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/split-ca": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split-ca/-/split-ca-1.0.1.tgz",
+      "integrity": "sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ==",
+      "license": "ISC"
+    },
     "node_modules/sprintf-js": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
@@ -10195,6 +10480,23 @@
       "resolved": "https://registry.npmjs.org/sql.js/-/sql.js-1.14.1.tgz",
       "integrity": "sha512-gcj8zBWU5cFsi9WUP+4bFNXAyF1iRpA3LLyS/DP5xlrNzGmPIizUeBggKa8DbDwdqaKwUcTEnChtd2grWo/x/A==",
       "license": "MIT"
+    },
+    "node_modules/ssh2": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.17.0.tgz",
+      "integrity": "sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "asn1": "^0.2.6",
+        "bcrypt-pbkdf": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      },
+      "optionalDependencies": {
+        "cpu-features": "~0.0.10",
+        "nan": "^2.23.0"
+      }
     },
     "node_modules/statuses": {
       "version": "2.0.2",
@@ -10228,7 +10530,6 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -10427,7 +10728,6 @@
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
       "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
@@ -10440,7 +10740,6 @@
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
       "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -10645,6 +10944,12 @@
         "url": "https://github.com/sponsors/Wombosvideo"
       }
     },
+    "node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
+      "license": "Unlicense"
+    },
     "node_modules/type-fest": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.5.0.tgz",
@@ -10703,7 +11008,6 @@
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {

--- a/app/package.json
+++ b/app/package.json
@@ -12,6 +12,7 @@
     "@github/copilot-sdk": "^1.0.5",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "dockerode": "^5.0.1",
     "express": "^4.21.0",
     "just-bash": "^2.14.0",
     "lucide-react": "^1.7.0",
@@ -34,6 +35,7 @@
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.19",
     "@tailwindcss/vite": "^4.2.2",
+    "@types/dockerode": "^4.0.1",
     "@types/express": "^5.0.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",

--- a/app/session-image/Dockerfile
+++ b/app/session-image/Dockerfile
@@ -1,0 +1,12 @@
+# Minimal image used to run one container per agent session.
+#
+# Based on stock Alpine with just the packages the agent's shell tool needs
+# (bash, python3, curl). No other customization, so it stays tiny and boots
+# in ~1-2 seconds.
+FROM alpine:3.21
+
+RUN apk add --no-cache bash python3 curl
+
+# Kept running with a no-op process; commands are executed in it via
+# `docker exec` (see ../src/api/docker/sessionContainer.ts).
+CMD ["sleep", "infinity"]

--- a/app/src/api/chatSocket.ts
+++ b/app/src/api/chatSocket.ts
@@ -7,8 +7,9 @@ import { join } from "path";
 import { validate as validateUuid } from "uuid";
 import { createDiskStorageProvider } from "./storage/diskStorageProvider.js";
 import { createInMemoryStorageProvider } from "./storage/inMemoryStorageProvider.js";
-import { createEnvironment, sessionFsConfig } from "./environment.js";
-import { Bash } from "just-bash";
+import { createEnvironment } from "./environments/index.js";
+import { sessionFsConfig } from "./sessionFsConfig.js";
+import { SessionEnvironment } from "./environments/types.js";
 import { restoreSessionFromFilestore, syncSessionToFilestore } from "./sessionSync.js";
 const sessionsDir = join(process.cwd(), "sessions");
 
@@ -28,6 +29,10 @@ const copilotClient = new CopilotClient({
 
 // Keep track of active sessions and their associated WebSocket connections
 const connectionManager = new ConnectionTracker(createOrResumeSession, releaseSessionResources);
+
+// Keep track of each session's environment so we can dispose of it (e.g. stop a container) when
+// the session ends
+const activeEnvironments = new Map<string, SessionEnvironment>();
 
 export function attachWebSocket(server: Server) {
   const wss = new WebSocketServer({ server, path: "/api/chat" });
@@ -65,7 +70,7 @@ export function attachWebSocket(server: Server) {
         if (command.content.startsWith("!")) {
           // Bang commands go directly into the environment's bash, bypassing the agent
           const cmd = command.content.slice(1).trim();
-          const cmdResult = await session.virtualBash.exec(cmd);
+          const cmdResult = await session.environment.execBangCommand(cmd);
           await ws.send(JSON.stringify({ type: "command.result", command: cmd, result: cmdResult }));
         } else {
           // Any other messages go to the agent
@@ -85,7 +90,7 @@ async function createOrResumeSession(sessionId: string, shouldResume: boolean) {
   }
 
   // Prepare an environment and corresponding SessionConfig
-  const environment = createEnvironment(sessionId, storage);
+  const environment = await createEnvironment(sessionId, sessionsDir, storage);
   const sessionConfig: SessionConfig = {
       ...environment.sessionConfig,
       sessionId,
@@ -95,12 +100,21 @@ async function createOrResumeSession(sessionId: string, shouldResume: boolean) {
       onPermissionRequest: approveAll,
   };
 
-  // Create or resume the session with this config
-  const session = shouldResume
-      ? await copilotClient.resumeSession(sessionId, sessionConfig)
-      : await copilotClient.createSession(sessionConfig);
-  const sessionWithEnvironment = session as CopilotSession & { virtualBash: Bash };
-  sessionWithEnvironment.virtualBash = environment.virtualBash;
+  // Create or resume the session with this config. If this throws, the environment we just
+  // created above (e.g. a started container) would otherwise be leaked, so make sure to
+  // dispose of it on failure.
+  let session: CopilotSession;
+  try {
+    session = shouldResume
+        ? await copilotClient.resumeSession(sessionId, sessionConfig)
+        : await copilotClient.createSession(sessionConfig);
+  } catch (err) {
+    await environment.dispose();
+    throw err;
+  }
+  const sessionWithEnvironment = session as CopilotSession & { environment: SessionEnvironment };
+  sessionWithEnvironment.environment = environment;
+  activeEnvironments.set(sessionId, environment);
 
   // Sync the session directory at each turn end
   enableSync && session.on("assistant.turn_end", async() => {
@@ -112,5 +126,7 @@ async function createOrResumeSession(sessionId: string, shouldResume: boolean) {
 
 // Invoked by ConnectionTracker when the last WebSocket connection for a session is closed
 async function releaseSessionResources(sessionId: string) {
+  await activeEnvironments.get(sessionId)?.dispose();
+  activeEnvironments.delete(sessionId);
   await storage.deleteSession(sessionId);
 }

--- a/app/src/api/containerFs.ts
+++ b/app/src/api/containerFs.ts
@@ -1,0 +1,100 @@
+import { promises as fs } from "fs";
+import { dirname, join, posix as posixPath, resolve, sep } from "path";
+import type { SessionFsProvider } from "@github/copilot-sdk";
+
+/*
+  A SessionFsProvider backed directly by a real directory on the host disk,
+  replacing the just-bash IFileSystem abstraction used previously.
+
+  The agent only ever deals in virtual, posix-style absolute paths (e.g.
+  "/foo/bar") rooted at `sessionFsConfig.initialCwd` ("/"). This provider maps
+  those onto real paths under `rootDir` and refuses to touch anything outside
+  it, so the agent - and the shell tool running in the session's container,
+  which bind-mounts this same directory - are both confined to `rootDir`.
+*/
+export function createContainerFs(rootDir: string): SessionFsProvider {
+    const resolvedRoot = resolve(rootDir);
+
+    function toRealPath(virtualPath: string): string {
+        // Normalizing as a posix path first collapses any ".." segments without
+        // ever escaping above "/", so the resulting real path is always within root.
+        const normalized = posixPath.normalize(`/${virtualPath}`);
+        const real = resolve(join(resolvedRoot, normalized));
+        if (real !== resolvedRoot && !real.startsWith(resolvedRoot + sep)) {
+            throw new Error(`Refusing to access path outside session root: ${virtualPath}`);
+        }
+        return real;
+    }
+
+    async function withEnoent<T>(virtualPath: string, fn: () => Promise<T>): Promise<T> {
+        try {
+            return await fn();
+        } catch (err: unknown) {
+            if (err && typeof err === "object" && (err as NodeJS.ErrnoException).code === "ENOENT") {
+                const ex = new Error(`ENOENT: no such file or directory, '${virtualPath}'`) as NodeJS.ErrnoException;
+                ex.code = "ENOENT";
+                ex.path = virtualPath;
+                throw ex;
+            }
+            throw err;
+        }
+    }
+
+    return {
+        readFile: (path) => withEnoent(path, () => fs.readFile(toRealPath(path), "utf8")),
+
+        writeFile: async (path, content, mode) => {
+            const real = toRealPath(path);
+            await fs.mkdir(dirname(real), { recursive: true });
+            await fs.writeFile(real, content, { mode });
+        },
+
+        appendFile: async (path, content, mode) => {
+            const real = toRealPath(path);
+            await fs.mkdir(dirname(real), { recursive: true });
+            await fs.appendFile(real, content, { mode });
+        },
+
+        exists: async (path) => {
+            try {
+                await fs.access(toRealPath(path));
+                return true;
+            } catch {
+                return false;
+            }
+        },
+
+        stat: (path) => withEnoent(path, async () => {
+            const st = await fs.stat(toRealPath(path));
+            return {
+                isFile: st.isFile(),
+                isDirectory: st.isDirectory(),
+                size: st.size,
+                mtime: st.mtime.toISOString(),
+                birthtime: st.birthtime.toISOString(),
+            };
+        }),
+
+        mkdir: async (path, recursive, mode) => {
+            await fs.mkdir(toRealPath(path), { recursive, mode });
+        },
+
+        readdir: (path) => withEnoent(path, () => fs.readdir(toRealPath(path))),
+
+        readdirWithTypes: (path) => withEnoent(path, async () => {
+            const entries = await fs.readdir(toRealPath(path), { withFileTypes: true });
+            return entries.map(entry => ({
+                name: entry.name,
+                type: entry.isDirectory() ? "directory" as const : "file" as const,
+            }));
+        }),
+
+        rm: async (path, recursive, force) => {
+            await fs.rm(toRealPath(path), { recursive, force });
+        },
+
+        rename: async (src, dest) => {
+            await fs.rename(toRealPath(src), toRealPath(dest));
+        },
+    };
+}

--- a/app/src/api/docker/image.ts
+++ b/app/src/api/docker/image.ts
@@ -1,0 +1,51 @@
+import Docker from "dockerode";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+
+// The image used for each session's container: stock Alpine plus the handful
+// of packages the agent's shell tool needs (bash, python3, curl). See
+// ../../../session-image/Dockerfile. It's small and boots in ~1-2 seconds.
+export const SESSION_IMAGE_TAG = "copilot-sdk-server-sample-session:latest";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const sessionImageDir = join(__dirname, "..", "..", "..", "session-image");
+
+let buildPromise: Promise<void> | undefined;
+
+// Builds (or rebuilds) the session container image exactly once per app process,
+// regardless of how many sessions concurrently ask for it.
+export function ensureSessionImageBuilt(docker: Docker): Promise<void> {
+    if (!buildPromise) {
+        buildPromise = buildImage(docker).catch(err => {
+            // Allow retrying on a later session if the build failed transiently
+            buildPromise = undefined;
+            throw err;
+        });
+    }
+    return buildPromise;
+}
+
+async function buildImage(docker: Docker): Promise<void> {
+    const images = await docker.listImages({ filters: JSON.stringify({ reference: [SESSION_IMAGE_TAG] }) });
+    if (images.length > 0) {
+        return;
+    }
+
+    console.log(`Building session container image (${SESSION_IMAGE_TAG})...`);
+    const stream = await docker.buildImage({ context: sessionImageDir, src: ["Dockerfile"] }, { t: SESSION_IMAGE_TAG });
+    await new Promise<void>((resolve, reject) => {
+        docker.modem.followProgress(
+            stream,
+            (err, res) => {
+                if (err) return reject(err);
+                const lastEntry = res[res.length - 1];
+                if (lastEntry?.error) {
+                    reject(new Error(lastEntry.error));
+                } else {
+                    resolve();
+                }
+            },
+        );
+    });
+    console.log(`Session container image built.`);
+}

--- a/app/src/api/docker/sessionContainer.ts
+++ b/app/src/api/docker/sessionContainer.ts
@@ -1,0 +1,168 @@
+import Docker from "dockerode";
+import { randomUUID } from "crypto";
+import { ensureSessionImageBuilt, SESSION_IMAGE_TAG } from "./image.js";
+
+export interface ExecResult {
+    stdout: string;
+    stderr: string;
+    exitCode: number | null;
+}
+
+// When the app itself runs inside a container (e.g. via docker-compose) whose
+// session directories are bind-mounted from the host, `docker.sock` (also
+// bind-mounted in) lets us talk to the *host's* Docker daemon to start sibling
+// containers - but any bind mount we ask that daemon to create must use a path
+// that's meaningful on the host, not inside our own container.
+//
+// HOST_SESSIONS_ROOT should be set to the host path that corresponds to
+// `sessionsRootDir` inside our own container (see docker-compose.yml). When
+// running the app directly on the host (no container), leave it unset - in
+// that case `sessionsRootDir` already *is* a host path.
+const HOST_SESSIONS_ROOT = process.env.HOST_SESSIONS_DIR;
+
+function toHostPath(sessionsRootDir: string, sessionDir: string): string {
+    if (!HOST_SESSIONS_ROOT) {
+        return sessionDir;
+    }
+    const rel = sessionDir.slice(sessionsRootDir.length).split(/[\\/]+/).filter(Boolean);
+    return [HOST_SESSIONS_ROOT.replace(/\/+$/, ""), ...rel].join("/");
+}
+
+const docker = new Docker();
+
+/*
+  Runs one small, disposable Docker container per session, giving the agent's
+  `bash` tool a real (but isolated) Linux shell instead of an in-process
+  simulation like just-bash. The session's working directory on the host is
+  bind-mounted read-write into the container at /workspace, so:
+    - Files the agent's other tools (read_file, write_file, etc, wired up via
+      SessionFsProvider in containerFs.ts) create on disk are immediately visible
+      to commands run in the container, and vice versa.
+    - Nothing else on the host is reachable from inside the container.
+
+  A single interactive `bash` process is kept running inside the container for
+  the lifetime of the session (via `docker exec`), so state like cwd, exported
+  environment variables, and shell functions persists across tool calls, the
+  same way a real terminal session would.
+*/
+export class SessionContainer {
+    private container: Docker.Container | undefined;
+    private stdin: NodeJS.WritableStream | undefined;
+    private outputBuffer = "";
+    private stderrBuffer = "";
+    private currentMarker: string | undefined;
+    private pendingResolve: ((r: ExecResult) => void) | undefined;
+    // Interactive bash only handles one command at a time, so we serialize
+    // exec() calls even if the caller doesn't await between them.
+    private execQueue: Promise<unknown> = Promise.resolve();
+
+    constructor(private readonly sessionsRootDir: string, private readonly sessionDir: string, private readonly sessionId: string) {}
+
+    async start(): Promise<void> {
+        await ensureSessionImageBuilt(docker);
+
+        const hostSessionDir = toHostPath(this.sessionsRootDir, this.sessionDir);
+        this.container = await docker.createContainer({
+            name: `copilot-session-${this.sessionId}`,
+            Image: SESSION_IMAGE_TAG,
+            Cmd: ["sleep", "infinity"],
+            WorkingDir: "/workspace",
+            HostConfig: {
+                Binds: [`${hostSessionDir}:/workspace:rw`],
+                AutoRemove: true,
+                // The container only needs to talk to the outside world via curl;
+                // it has no need for elevated host access.
+                CapDrop: ["ALL"],
+            },
+            Tty: false,
+        });
+        await this.container.start();
+
+        // Start one long-lived interactive bash process we can pipe commands into,
+        // so shell state (cwd, env vars, etc) is preserved between tool calls.
+        const exec = await this.container.exec({
+            Cmd: ["bash", "--noprofile", "--norc"],
+            AttachStdin: true,
+            AttachStdout: true,
+            AttachStderr: true,
+        });
+        const stream = await exec.start({ hijack: true, stdin: true });
+
+        const stdout = { write: (chunk: Buffer) => this.onStdout(chunk) };
+        const stderr = { write: (chunk: Buffer) => this.onStderr(chunk) };
+        docker.modem.demuxStream(stream, stdout as any, stderr as any);
+
+        this.stdin = stream;
+    }
+
+    // Runs a command in the session's persistent interactive bash session and
+    // waits for it to complete, returning its output and exit code. Commands
+    // are serialized: if called again before the previous one finishes, it
+    // simply waits its turn, just like typing into a real terminal would.
+    exec(command: string): Promise<ExecResult> {
+        const runNext = () => this.runOne(command);
+        const result = this.execQueue.then(runNext, runNext);
+        // Swallow errors here so a failed command doesn't break the queue chain
+        // for subsequent commands; the caller still gets the rejection/result.
+        this.execQueue = result.catch(() => {});
+        return result;
+    }
+
+    private runOne(command: string): Promise<ExecResult> {
+        if (!this.stdin) {
+            throw new Error("SessionContainer has not been started");
+        }
+
+        const marker = `__CMD_DONE_${randomUUID()}__`;
+        const resultPromise = new Promise<ExecResult>(resolve => {
+            this.pendingResolve = resolve;
+        });
+
+        this.outputBuffer = "";
+        this.stderrBuffer = "";
+        this.currentMarker = marker;
+        this.stdin.write(`${command}\n`);
+        this.stdin.write(`echo "${marker}:$?"\n`);
+
+        return resultPromise;
+    }
+
+    private onStdout(chunk: Buffer) {
+        this.outputBuffer += chunk.toString("utf8");
+        this.tryComplete();
+    }
+
+    private onStderr(chunk: Buffer) {
+        this.stderrBuffer += chunk.toString("utf8");
+    }
+
+    private tryComplete() {
+        if (!this.currentMarker) return;
+        const markerIndex = this.outputBuffer.indexOf(this.currentMarker);
+        if (markerIndex === -1) return;
+
+        const markerLine = this.outputBuffer.slice(markerIndex);
+        const match = markerLine.match(/:(-?\d+)/);
+        const exitCode = match ? Number(match[1]) : null;
+        const stdout = this.outputBuffer.slice(0, markerIndex);
+        const stderr = this.stderrBuffer;
+
+        this.currentMarker = undefined;
+        this.outputBuffer = "";
+        this.stderrBuffer = "";
+
+        const resolve = this.pendingResolve;
+        this.pendingResolve = undefined;
+        resolve?.({ stdout, stderr, exitCode });
+    }
+
+    async stop(): Promise<void> {
+        try {
+            await this.container?.stop({ t: 1 });
+        } catch {
+            // Already stopped/removed (AutoRemove) - nothing to do
+        }
+        this.container = undefined;
+        this.stdin = undefined;
+    }
+}

--- a/app/src/api/environments/containerEnvironment.ts
+++ b/app/src/api/environments/containerEnvironment.ts
@@ -1,0 +1,88 @@
+import { SessionConfig, ToolSet, BuiltInTools, defineTool } from "@github/copilot-sdk";
+import { z } from "zod";
+import { createContainerFs } from "../containerFs";
+import { SessionContainer } from "../docker/sessionContainer";
+import { StorageProvider } from "../storage/storageProvider";
+import { ExecResult, SessionEnvironment } from "./types";
+
+// An alternative session environment: each session gets its own small, disposable Linux
+// container (built from app/session-image/Dockerfile) instead of an in-process simulation.
+// The session's directory on disk is bind-mounted read-write into the container at
+// /workspace, so file tools (wired up via containerFs.ts) and the bash tool both operate on
+// the same real files. Requires Docker to be installed and running - see README "Switching to
+// container-based isolation".
+
+export async function createContainerEnvironment(sessionId: string, sessionsRootDir: string, storage: StorageProvider): Promise<SessionEnvironment> {
+    const sessionDir = storage.getSessionDir(sessionId);
+    const fs = createContainerFs(sessionDir);
+
+    const container = new SessionContainer(sessionsRootDir, sessionDir, sessionId);
+    await container.start();
+
+    const bashTools = [
+        defineTool("bash", {
+            description: `Runs a bash command in an interactive bash session.`,
+            parameters: z.object({
+                command: z.string().describe(`The bash command and arguments to run.`),
+                description: z.string().describe(`A short human-readable description of what the command does, limited to 100 characters.`),
+            }),
+            overridesBuiltInTool: true,
+            handler: async ({ command }) => {
+                const result = await container.exec(command);
+                return result.exitCode === 0 ? result.stdout : `Exited with code ${result.exitCode}; stderr: ${result.stderr}`;
+            },
+        })
+    ];
+
+    const sessionConfig: Partial<SessionConfig> = {
+        availableTools: new ToolSet()
+            .addBuiltIn(BuiltInTools.Isolated)
+            .addCustom("*"),
+        tools: [...bashTools],
+        createSessionFsProvider: () => fs,
+        systemMessage: {
+            mode: "customize",
+            sections: {
+                identity: {
+                    action: "replace",
+                    content: `You are an assistant called "The Session Server Sample Agent". Your purpose is to
+                    help the user with any tasks they have, using the tools available to you.
+
+                    If the user asks you about this app and how it works, use the web_fetch tool to retrieve
+                    information from the README.md on https://github.com/github/copilot-sdk-server-sample.
+                    That's also where your own source code lives, so you can read it to get more detailed information
+                    about how this sample works. Useful talking points about this sample:
+                     - Each session has an isolated filesystem and a Bash tool that runs commands inside a small,
+                       disposable Linux container dedicated to that session
+                     - The user can ask you to write Python scripts or invoke curl (which is limited to preconfigured hosts)
+                     - They can use \`!<command>\` to run any bash command directly (e.g., \`!ls -la /\`)
+                     - They can open the same session in multiple browser tabs and see updates stream to all of them
+                    `
+                },
+
+                // TODO: Instead of doing a "replace" here, consider assigning totally separate system prompt, not using the
+                // built-in coding agent prompt. The coding agent system prompt contains some information about the host (including
+                // <session_context> that refers to paths on the host), and heavily tunes it towards programming tasks.
+                environment_context: {
+                    action: "replace",
+                    content: `
+                        Within this environment, there is a \`python\` command but it has limitations:
+                        - It can't access the network directly. If you need to make HTTP requests, use \`curl\`.
+                        - It can't accept input from stdin. If you want to use \`python\` to process data, you must write the data to a temp file first.
+                        Other tools like \`jq\` can be used for processing data as well, and they don't have these limitations.
+
+                        You are not in a Git repostitory. You are in an isolated environment with its own filesystem
+                        (a directory on the server, bind-mounted into your own dedicated Linux container).
+                        Use the filesystem as a working environment in which to store any files needed to complete your tasks.
+                    `
+                },
+            },
+        }
+    };
+
+    return {
+        sessionConfig,
+        execBangCommand: (command: string): Promise<ExecResult> => container.exec(command),
+        dispose: () => container.stop(),
+    };
+}

--- a/app/src/api/environments/index.ts
+++ b/app/src/api/environments/index.ts
@@ -1,0 +1,11 @@
+import { CreateEnvironment } from "./types";
+import { createJustBashEnvironment } from "./justBashEnvironment";
+// import { createContainerEnvironment } from "./containerEnvironment";
+
+// Which session isolation strategy to use is chosen right here in code (not via an env var),
+// since it's a fixed choice for how you want to run this sample, not something that varies
+// per request. just-bash (the default) needs no extra setup. To switch to container-based
+// isolation instead, comment out the line below and uncomment the one after it - see README
+// "Switching to container-based isolation" for what that requires.
+export const createEnvironment: CreateEnvironment = createJustBashEnvironment;
+// export const createEnvironment: CreateEnvironment = createContainerEnvironment;

--- a/app/src/api/environments/justBashEnvironment.ts
+++ b/app/src/api/environments/justBashEnvironment.ts
@@ -1,12 +1,13 @@
-import { CopilotSession, SessionConfig, SessionFsConfig, SessionFsProvider, ToolSet, BuiltInTools } from "@github/copilot-sdk";
-import { Bash, IFileSystem } from "just-bash";
-import { createBash } from "./bash";
-import { StorageProvider } from "./storage/storageProvider";
+import { CopilotSession, SessionConfig, SessionFsProvider, ToolSet, BuiltInTools } from "@github/copilot-sdk";
+import { IFileSystem } from "just-bash";
+import { createBash } from "../bash";
+import { StorageProvider } from "../storage/storageProvider";
+import { ExecResult, SessionEnvironment } from "./types";
 
-// In this sample, an "environment" is responsible for creating an isolated filesystem and Bash instance
-// and supplies a SessionConfig that configures Copilot to use them.
+// The default session environment: an in-process virtual filesystem and shell simulator
+// (the "just-bash" package), requiring no extra setup (no Docker needed).
 
-export function createEnvironment(sessionId: string, storage: StorageProvider): { virtualBash: Bash, sessionConfig: Partial<SessionConfig> } {
+export async function createJustBashEnvironment(sessionId: string, sessionsRootDir: string, storage: StorageProvider): Promise<SessionEnvironment> {
     const fs = storage.createFileSystem(sessionId);
     const { virtualBash, virtualBashTools } = createBash(fs);
 
@@ -54,16 +55,17 @@ export function createEnvironment(sessionId: string, storage: StorageProvider): 
         }
     };
 
-    return { virtualBash, sessionConfig };
+    return {
+        sessionConfig,
+        execBangCommand: (command: string): Promise<ExecResult> => virtualBash.exec(command),
+        dispose: async () => {
+            // Nothing to release - the virtual filesystem and bash simulator are just in-process
+            // objects with no external resources.
+        },
+    };
 }
 
-export const sessionFsConfig: SessionFsConfig = {
-    initialCwd: "/",
-    sessionStatePath: "/session-state",
-    conventions: "posix"
-};
-
-// An adapter from a just-bash IFileSystem to the Copilot runtime SessionFsConfig interface
+// An adapter from a just-bash IFileSystem to the Copilot runtime's SessionFsProvider interface
 function createSessionFsProvider(session: CopilotSession, fileSystem: IFileSystem): SessionFsProvider {
     return {
         readFile: async (path) => {
@@ -94,7 +96,7 @@ function createSessionFsProvider(session: CopilotSession, fileSystem: IFileSyste
         readdirWithTypes: async (path) => {
             const names = await fileSystem.readdir(path);
             return await Promise.all(
-                names.map(async (name) => {
+                names.map(async (name: string) => {
                     const st = await fileSystem.stat(`${path}/${name}`);
                     return { name, type: st.isDirectory ? "directory" as const : "file" as const };
                 }),

--- a/app/src/api/environments/types.ts
+++ b/app/src/api/environments/types.ts
@@ -1,0 +1,27 @@
+import { SessionConfig } from "@github/copilot-sdk";
+import { StorageProvider } from "../storage/storageProvider";
+
+export interface ExecResult {
+    stdout: string;
+    stderr: string;
+    exitCode: number | null;
+}
+
+// A "session environment" bundles together everything needed to give a session an isolated
+// place to work: a filesystem, a way to run shell commands in it, and the SessionConfig that
+// wires those into the Copilot runtime's tools. This app ships two implementations - just-bash
+// (the default; an in-process virtual filesystem + shell simulator) and container-based (a
+// real, disposable Linux container per session) - selected by a single line of code in
+// chatSocket.ts, so no isolation-specific branching is needed anywhere else.
+export interface SessionEnvironment {
+    sessionConfig: Partial<SessionConfig>;
+
+    // Runs a `!command` bang-command directly, bypassing the agent
+    execBangCommand(command: string): Promise<ExecResult>;
+
+    // Releases any resources (e.g. a running container) held for this session. Called once the
+    // last WebSocket connection for the session disconnects.
+    dispose(): Promise<void>;
+}
+
+export type CreateEnvironment = (sessionId: string, sessionsRootDir: string, storage: StorageProvider) => Promise<SessionEnvironment>;

--- a/app/src/api/sessionFsConfig.ts
+++ b/app/src/api/sessionFsConfig.ts
@@ -1,0 +1,7 @@
+import { SessionFsConfig } from "@github/copilot-sdk";
+
+export const sessionFsConfig: SessionFsConfig = {
+    initialCwd: "/",
+    sessionStatePath: "/session-state",
+    conventions: "posix"
+};

--- a/app/src/api/storage/diskStorageProvider.ts
+++ b/app/src/api/storage/diskStorageProvider.ts
@@ -27,5 +27,11 @@ export function createDiskStorageProvider(root: string): StorageProvider {
             mkdirSync(dir, { recursive: true });
             return new ReadWriteFs({ root: dir });
         },
+
+        getSessionDir: (sessionId: string) => {
+            const dir = join(root, sessionId);
+            mkdirSync(dir, { recursive: true });
+            return dir;
+        },
     };
 }

--- a/app/src/api/storage/inMemoryStorageProvider.ts
+++ b/app/src/api/storage/inMemoryStorageProvider.ts
@@ -21,5 +21,12 @@ export function createInMemoryStorageProvider(): StorageProvider {
             }
             return inMemoryFileSystems.get(sessionId)!;
         },
+
+        getSessionDir: (sessionId: string) => {
+            throw new Error(
+                "The in-memory storage provider has no real directory to expose. The container-based " +
+                "environment needs a real host directory to bind-mount, so it requires disk-based storage."
+            );
+        },
     };
 }

--- a/app/src/api/storage/storageProvider.ts
+++ b/app/src/api/storage/storageProvider.ts
@@ -7,6 +7,11 @@ export interface StorageProvider {
     // Releases any resources we're holding for the session within the app server
     deleteSession(sessionId: string): Promise<void>;
 
-    // Supplies just-bash IFileSystem instances for a session
+    // Supplies just-bash IFileSystem instances for a session (used by the just-bash environment)
     createFileSystem(sessionId: string): IFileSystem;
+
+    // Returns the real, on-disk directory for a session (used by the container-based
+    // environment, which needs a host directory it can bind-mount into a container).
+    // Throws if this storage provider doesn't back sessions with a real directory.
+    getSessionDir(sessionId: string): string;
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,11 @@ services:
     volumes:
       - ./app:/app
       - /app/node_modules # preserve container's node_modules
+      # Only needed if you've switched to container-based session isolation (see
+      # app/src/api/environments/index.ts) AND you're running this app itself via
+      # docker-compose. It lets the app talk to the host's Docker daemon to start one
+      # sibling container per session - uncomment if you need it:
+      # - /var/run/docker.sock:/var/run/docker.sock
     environment:
       - NODE_ENV=development
       - GITHUB_TOKEN=${GITHUB_TOKEN:?Set an environment variable GITHUB_TOKEN before running docker compose up. You can create a fine-grained token (no permissions needed) on https://github.com/settings/personal-access-tokens or run "gh auth token" if you have the GitHub CLI installed.}
@@ -16,6 +21,10 @@ services:
       - SESSION_FILESTORE_HOST=rsync-filestore
       - SESSION_FILESTORE_PORT=873
       - USE_IN_MEMORY_VFS=${USE_IN_MEMORY_VFS:-}
+      # Only needed together with the docker.sock mount above: the host path that
+      # corresponds to ./app/sessions, so container bind mounts (resolved by the host's
+      # Docker daemon) use a path that's meaningful on the host, not inside this container.
+      # - HOST_SESSIONS_DIR=${PWD}/app/sessions
     depends_on:
       - rsync-filestore
 


### PR DESCRIPTION
## Summary

Restores just-bash as the default session shell/filesystem isolation strategy (after it was previously replaced entirely by Docker-container isolation on `main`), while keeping container-based isolation available as an easy opt-in.

- Introduces a `SessionEnvironment` interface (`app/src/api/environments/types.ts`) with two implementations:
  - `justBashEnvironment.ts` (default) — reuses the original `bash.ts` unmodified, so default behavior is unchanged.
  - `containerEnvironment.ts` (opt-in) — runs each session'"'"'s shell in its own disposable Docker container.
- Strategy is selected by a single line in `app/src/api/environments/index.ts`, with the alternative commented out alongside its import — no env var, no scattered if/else.
- `chatSocket.ts` is now isolation-agnostic: bang-commands and disposal go through `session.environment`; active environments are tracked and disposed on session end or failed create/resume (avoiding container leaks).
- Storage providers gain `getSessionDir()` (disk returns a real path; in-memory throws, since container mode needs a real host directory to bind-mount).
- `docker-compose.yml` gets a commented-out Docker socket mount + `HOST_SESSIONS_DIR`, only needed if running the app itself via compose with container mode enabled.
- README documents the switch.

## Verification

- `npx tsc --noEmit` passes with 0 errors.
- `docker compose config` validates the updated compose file.
- Not yet runtime-tested end-to-end in this session (deferred pending available credentials); marked as draft for that reason.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>